### PR TITLE
feat: Event-driven approach for message of the day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Modules get a copy of build.gradle as they are not allowed to have their own (for build security / sandboxing)
+build.gradle
+
+# IntelliJ
+*.iml
+
+# Eclipse
+.checkstyle
+.classpath
+.project
+.settings
+bin/
+
+build/
+
+# MacOS Specific
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # ServerMOTD
 
-A module which factors out the Server MOTD functionality into a module.
+A module which implements the functionality to display a MOTD when a client joins.
 
 ####Commands in module
+
+- **displayMOTD**
+This command can be used by the server host as well as the connected clients to view the current MOTD.
+
 - **editMOTD:** 
 This command can be run by the server host only, to edit the MOTD in-game. Parameters that can be used are 
 a - To append the provided string at the end of current MOTD. 
 w - To replace the current MOTD with the provided string.
 
-- **displayMOTD**
-This command can be used by the server host as well as the connected clients to view the current MOTD.
+- **overwriteMOTD**
+This command is same as using `editMOTD` with the `w` argument.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# ServerMOTD
+
+A module which factors out the Server MOTD functionality into a module.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # ServerMOTD
 
 A module which factors out the Server MOTD functionality into a module.
+
+####Commands in module
+- **editMOTD:** 
+This command can be run by the server host only, to edit the MOTD in-game. Parameters that can be used are 
+a - To append the provided string at the end of current MOTD. 
+w - To replace the current MOTD with the provided string.
+
+- **displayMOTD**
+This command can be used by the server host as well as the connected clients to view the current MOTD.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ A module which implements the functionality to display a MOTD when a client join
 
 ####Commands in module
 
+- **appendToMOTD:**
+This command can be run by the server host only, to edit the MOTD in-game. The message provided as an argument wtih the command is appended at the end of the current MOTD.
+
 - **displayMOTD**
 This command can be used by the server host as well as the connected clients to view the current MOTD.
 
-- **editMOTD:** 
-This command can be run by the server host only, to edit the MOTD in-game. Parameters that can be used are 
-a - To append the provided string at the end of current MOTD. 
-w - To replace the current MOTD with the provided string.
-
 - **overwriteMOTD**
-This command is same as using `editMOTD` with the `w` argument.
+This command can be run by the server host only, to edit the MOTD in-game. The message provided as an argument wtih the command is overwrites the current MOTD.

--- a/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.servermotd;
+
+import org.terasology.context.Context;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.console.commandSystem.annotations.Command;
+import org.terasology.logic.permission.PermissionManager;
+import org.terasology.registry.CoreRegistry;
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class ClientMOTDSystem extends BaseComponentSystem implements Event {
+
+    private EntityRef entity = EntityRef.NULL;
+
+    private Context context = CoreRegistry.get(Context.class);
+
+    public void initialise() {
+        entity.send(new DisplayMOTDEvent());
+    }
+
+    @Command(shortDescription = "Displays server MOTD", runOnServer = true, requiredPermission = PermissionManager.NO_PERMISSION)
+    public void displayMOTD() {
+        entity.send(new DisplayMOTDEvent());
+    }
+}

--- a/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
@@ -22,6 +22,7 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
+import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.permission.PermissionManager;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
@@ -49,5 +50,28 @@ public class ClientMOTDSystem extends BaseComponentSystem {
     public void displayMOTD() {
         entity = renderMOTD.getMOTDEntity(entityManager);
         renderMOTD.display(entity.getComponent(MOTDComponent.class).motd, context);
+    }
+
+    @Command(shortDescription = "Edit server MOTD", helpText = "Edit the current server MOTD if you are admin." +
+            " Use \'a\' - to append to current MOTD" +
+            " 'w' for a new one", requiredPermission = PermissionManager.CHEAT_PERMISSION)
+    public String editMOTD (@CommandParam(value = "a/w") String type, @CommandParam(value = "New Message") String message) {
+        entity = renderMOTD.getMOTDEntity(entityManager);
+        MOTDComponent comp = entity.getComponent(MOTDComponent.class);
+        switch (type) {
+            case "a":
+                comp.motd += message;
+                break;
+
+            case "w":
+                comp.motd = message;
+                break;
+
+            default:
+            return "Error in command syntax, use help editMOTD command for help";
+        }
+
+        entity.saveComponent(comp);
+        return "Server MOTD edited use displayMOTD command to view the new MOTD";
     }
 }

--- a/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
@@ -46,37 +46,26 @@ public class ClientMOTDSystem extends BaseComponentSystem {
         displayMOTD();
     }
 
+    @Command(shortDescription = "Append to server MOTD", helpText = "Append a message to the current server MOTD if you are admin.",
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
+    public String appendToMOTD (@CommandParam(value = "New Message") String message) {
+        entity = renderMOTD.getMOTDEntity(entityManager);
+        MOTDComponent comp = entity.getComponent(MOTDComponent.class);
+
+        message = " " + message;
+        comp.motd += message;
+
+        entity.saveComponent(comp);
+        return "Server MOTD edited use displayMOTD command to view the new MOTD";
+    }
+
     @Command(shortDescription = "Displays server MOTD", requiredPermission = PermissionManager.NO_PERMISSION)
     public void displayMOTD() {
         entity = renderMOTD.getMOTDEntity(entityManager);
         renderMOTD.display(entity.getComponent(MOTDComponent.class).motd, context);
     }
 
-    @Command(shortDescription = "Edit server MOTD", helpText = "Edit the current server MOTD if you are admin." +
-            " Use 'a' - to append to current MOTD" +
-            " 'w' for a new one", requiredPermission = PermissionManager.CHEAT_PERMISSION)
-    public String editMOTD (@CommandParam(value = "a/w") String type, @CommandParam(value = "New Message") String message) {
-        entity = renderMOTD.getMOTDEntity(entityManager);
-        MOTDComponent comp = entity.getComponent(MOTDComponent.class);
-        switch (type) {
-            case "a":
-                comp.motd += message;
-                break;
-
-            case "w":
-                comp.motd = message;
-                break;
-
-            default:
-            return "Error in command syntax, use help editMOTD command for help";
-        }
-
-        entity.saveComponent(comp);
-        return "Server MOTD edited use displayMOTD command to view the new MOTD";
-    }
-
-    @Command(shortDescription = "Overwites the current server MOTD", helpText = "Overwrites the current server MOTD if you are admin." +
-            "Same as using the 'w' argument with editMOTD command"
+    @Command(shortDescription = "Overwites the current server MOTD", helpText = "Overwrites the current server MOTD if you are admin."
             , requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String overwriteMOTD (@CommandParam(value = "New Message") String message) {
         entity = renderMOTD.getMOTDEntity(entityManager);

--- a/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
@@ -53,7 +53,7 @@ public class ClientMOTDSystem extends BaseComponentSystem {
     }
 
     @Command(shortDescription = "Edit server MOTD", helpText = "Edit the current server MOTD if you are admin." +
-            " Use \'a\' - to append to current MOTD" +
+            " Use 'a' - to append to current MOTD" +
             " 'w' for a new one", requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String editMOTD (@CommandParam(value = "a/w") String type, @CommandParam(value = "New Message") String message) {
         entity = renderMOTD.getMOTDEntity(entityManager);
@@ -70,6 +70,19 @@ public class ClientMOTDSystem extends BaseComponentSystem {
             default:
             return "Error in command syntax, use help editMOTD command for help";
         }
+
+        entity.saveComponent(comp);
+        return "Server MOTD edited use displayMOTD command to view the new MOTD";
+    }
+
+    @Command(shortDescription = "Overwites the current server MOTD", helpText = "Overwrites the current server MOTD if you are admin." +
+            "Same as using the 'w' argument with editMOTD command"
+            , requiredPermission = PermissionManager.CHEAT_PERMISSION)
+    public String overwriteMOTD (@CommandParam(value = "New Message") String message) {
+        entity = renderMOTD.getMOTDEntity(entityManager);
+        MOTDComponent comp = entity.getComponent(MOTDComponent.class);
+
+        comp.motd = message;
 
         entity.saveComponent(comp);
         return "Server MOTD edited use displayMOTD command to view the new MOTD";

--- a/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
@@ -41,13 +41,8 @@ public class ClientMOTDSystem extends BaseComponentSystem {
 
     }
 
-    @Override
-    public void postBegin() {
-        displayMOTD();
-    }
-
     @Command(shortDescription = "Append to server MOTD", helpText = "Append a message to the current server MOTD if you are admin.",
-            requiredPermission = PermissionManager.CHEAT_PERMISSION)
+            requiredPermission = PermissionManager.CHEAT_PERMISSION, runOnServer = true)
     public String appendToMOTD (@CommandParam(value = "New Message") String message) {
         entity = renderMOTD.getMOTDEntity(entityManager);
         MOTDComponent comp = entity.getComponent(MOTDComponent.class);
@@ -66,7 +61,7 @@ public class ClientMOTDSystem extends BaseComponentSystem {
     }
 
     @Command(shortDescription = "Overwites the current server MOTD", helpText = "Overwrites the current server MOTD if you are admin."
-            , requiredPermission = PermissionManager.CHEAT_PERMISSION)
+            , requiredPermission = PermissionManager.CHEAT_PERMISSION, runOnServer = true)
     public String overwriteMOTD (@CommandParam(value = "New Message") String message) {
         entity = renderMOTD.getMOTDEntity(entityManager);
         MOTDComponent comp = entity.getComponent(MOTDComponent.class);

--- a/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
@@ -15,9 +15,6 @@
  */
 package org.terasology.servermotd;
 
-import org.terasology.context.Context;
-import org.terasology.entitySystem.entity.EntityManager;
-import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -25,9 +22,7 @@ import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.LocalPlayer;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
-import org.terasology.rendering.nui.NUIManager;
 import org.terasology.servermotd.events.DisplayMotdEvent;
 import org.terasology.servermotd.events.EditMotdEvent;
 
@@ -36,19 +31,18 @@ public class ClientMOTDSystem extends BaseComponentSystem {
     @In
     LocalPlayer localPlayer;
 
-    @In
-    private Context context;
-
-    public void initialise() {
-
+    @Override
+    public void postBegin() {
+        displayMotd();
     }
 
     @Command(shortDescription = "Append to server MOTD",
             helpText = "Append a message to the current server MOTD if you are admin.",
-            requiredPermission = PermissionManager.CHEAT_PERMISSION,
-            runOnServer = true)
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String appendToMotd (@CommandParam(value = "New Message") String message) {
-        EditMotdEvent editEvent = new EditMotdEvent(false, message);
+        EditMotdEvent editEvent = new EditMotdEvent();
+        editEvent.setEditMessage(message);
+        editEvent.setOverwriteMotd(false);
         localPlayer.getCharacterEntity().send(editEvent);
 
         return "Server MOTD edited use displayMOTD command to view the new MOTD";
@@ -57,16 +51,17 @@ public class ClientMOTDSystem extends BaseComponentSystem {
     @Command(shortDescription = "Displays server MOTD",
             requiredPermission = PermissionManager.NO_PERMISSION)
     public void displayMotd() {
-        NUIManager nuiManager = context.get(NUIManager.class);
-        localPlayer.getCharacterEntity().send(new DisplayMotdEvent(nuiManager));
+        DisplayMotdEvent displayEvent = new DisplayMotdEvent();
+        localPlayer.getCharacterEntity().send(displayEvent);
     }
 
     @Command(shortDescription = "Overwites the current server MOTD",
             helpText = "Overwrites the current server MOTD if you are admin.",
-            requiredPermission = PermissionManager.CHEAT_PERMISSION,
-            runOnServer = true)
+            requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String overwriteMotd (@CommandParam(value = "New Message") String message) {
-        EditMotdEvent editEvent = new EditMotdEvent(true, message);
+        EditMotdEvent editEvent = new EditMotdEvent();
+        editEvent.setOverwriteMotd(true);
+        editEvent.setEditMessage(message);
         localPlayer.getCharacterEntity().send(editEvent);
         return "Server MOTD edited use displayMOTD command to view the new MOTD";
     }

--- a/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
@@ -24,51 +24,50 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.permission.PermissionManager;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.servermotd.events.DisplayMotdEvent;
+import org.terasology.servermotd.events.EditMotdEvent;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class ClientMOTDSystem extends BaseComponentSystem {
     @In
-    private EntityManager entityManager;
+    LocalPlayer localPlayer;
 
-    private MOTDProvider renderMOTD = new MOTDProvider();
-
-    private Context context = CoreRegistry.get(Context.class);
-    private EntityRef entity;
+    @In
+    private Context context;
 
     public void initialise() {
 
     }
 
-    @Command(shortDescription = "Append to server MOTD", helpText = "Append a message to the current server MOTD if you are admin.",
-            requiredPermission = PermissionManager.CHEAT_PERMISSION, runOnServer = true)
-    public String appendToMOTD (@CommandParam(value = "New Message") String message) {
-        entity = renderMOTD.getMOTDEntity(entityManager);
-        MOTDComponent comp = entity.getComponent(MOTDComponent.class);
+    @Command(shortDescription = "Append to server MOTD",
+            helpText = "Append a message to the current server MOTD if you are admin.",
+            requiredPermission = PermissionManager.CHEAT_PERMISSION,
+            runOnServer = true)
+    public String appendToMotd (@CommandParam(value = "New Message") String message) {
+        EditMotdEvent editEvent = new EditMotdEvent(false, message);
+        localPlayer.getCharacterEntity().send(editEvent);
 
-        message = " " + message;
-        comp.motd += message;
-
-        entity.saveComponent(comp);
         return "Server MOTD edited use displayMOTD command to view the new MOTD";
     }
 
-    @Command(shortDescription = "Displays server MOTD", requiredPermission = PermissionManager.NO_PERMISSION)
-    public void displayMOTD() {
-        entity = renderMOTD.getMOTDEntity(entityManager);
-        renderMOTD.display(entity.getComponent(MOTDComponent.class).motd, context);
+    @Command(shortDescription = "Displays server MOTD",
+            requiredPermission = PermissionManager.NO_PERMISSION)
+    public void displayMotd() {
+        NUIManager nuiManager = context.get(NUIManager.class);
+        localPlayer.getCharacterEntity().send(new DisplayMotdEvent(nuiManager));
     }
 
-    @Command(shortDescription = "Overwites the current server MOTD", helpText = "Overwrites the current server MOTD if you are admin."
-            , requiredPermission = PermissionManager.CHEAT_PERMISSION, runOnServer = true)
-    public String overwriteMOTD (@CommandParam(value = "New Message") String message) {
-        entity = renderMOTD.getMOTDEntity(entityManager);
-        MOTDComponent comp = entity.getComponent(MOTDComponent.class);
-
-        comp.motd = message;
-
-        entity.saveComponent(comp);
+    @Command(shortDescription = "Overwites the current server MOTD",
+            helpText = "Overwrites the current server MOTD if you are admin.",
+            requiredPermission = PermissionManager.CHEAT_PERMISSION,
+            runOnServer = true)
+    public String overwriteMotd (@CommandParam(value = "New Message") String message) {
+        EditMotdEvent editEvent = new EditMotdEvent(true, message);
+        localPlayer.getCharacterEntity().send(editEvent);
         return "Server MOTD edited use displayMOTD command to view the new MOTD";
     }
 }

--- a/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ClientMOTDSystem.java
@@ -16,28 +16,38 @@
 package org.terasology.servermotd;
 
 import org.terasology.context.Context;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.Event;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.permission.PermissionManager;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
 
 @RegisterSystem(RegisterMode.CLIENT)
-public class ClientMOTDSystem extends BaseComponentSystem implements Event {
+public class ClientMOTDSystem extends BaseComponentSystem {
+    @In
+    private EntityManager entityManager;
 
-    private EntityRef entity = EntityRef.NULL;
+    private MOTDProvider renderMOTD = new MOTDProvider();
 
     private Context context = CoreRegistry.get(Context.class);
+    private EntityRef entity;
 
     public void initialise() {
-        entity.send(new DisplayMOTDEvent());
+
     }
 
-    @Command(shortDescription = "Displays server MOTD", runOnServer = true, requiredPermission = PermissionManager.NO_PERMISSION)
+    @Override
+    public void postBegin() {
+        displayMOTD();
+    }
+
+    @Command(shortDescription = "Displays server MOTD", requiredPermission = PermissionManager.NO_PERMISSION)
     public void displayMOTD() {
-        entity.send(new DisplayMOTDEvent());
+        entity = renderMOTD.getMOTDEntity(entityManager);
+        renderMOTD.display(entity.getComponent(MOTDComponent.class).motd, context);
     }
 }

--- a/src/main/java/org/terasology/servermotd/DisplayMOTDEvent.java
+++ b/src/main/java/org/terasology/servermotd/DisplayMOTDEvent.java
@@ -15,6 +15,9 @@
  */
 package org.terasology.servermotd;
 
-public interface ServerMOTD {
-    void initialise();
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.OwnerEvent;
+
+@OwnerEvent
+public class DisplayMOTDEvent implements Event {
 }

--- a/src/main/java/org/terasology/servermotd/MOTDComponent.java
+++ b/src/main/java/org/terasology/servermotd/MOTDComponent.java
@@ -15,9 +15,11 @@
  */
 package org.terasology.servermotd;
 
-import org.terasology.entitySystem.event.Event;
-import org.terasology.network.OwnerEvent;
+import org.terasology.entitySystem.Component;
+import org.terasology.network.FieldReplicateType;
+import org.terasology.network.Replicate;
 
-@OwnerEvent
-public class DisplayMOTDEvent implements Event {
+public class MOTDComponent implements Component {
+    @Replicate(value = FieldReplicateType.SERVER_TO_CLIENT)
+    public String motd;
 }

--- a/src/main/java/org/terasology/servermotd/MOTDProvider.java
+++ b/src/main/java/org/terasology/servermotd/MOTDProvider.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.servermotd;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -34,9 +36,18 @@ public class MOTDProvider {
     public EntityRef getMOTDEntity(EntityManager entityManager) {
         Iterable<EntityRef> motdEntities = entityManager.getEntitiesWith(MOTDComponent.class);
         Iterator<EntityRef> i = motdEntities.iterator();
+        Logger logger = LoggerFactory.getLogger(MOTDProvider.class);
 
         if(i.hasNext()) {
-            return i.next();
+            logger.info("Used old entity");
+            int sum = 0;
+            EntityRef entityRef = i.next();
+            while(i.hasNext()) {
+                entityRef = i.next();
+                sum++;
+            }
+            logger.info(Integer.toString(sum + 1));
+            return entityRef;
         }
         else {
             MOTDComponent motdComp = new MOTDComponent();
@@ -47,6 +58,8 @@ public class MOTDProvider {
             NetworkComponent netComp = new NetworkComponent();
             netComp.replicateMode = NetworkComponent.ReplicateMode.ALWAYS;
             entityRef.addComponent(netComp);
+
+            logger.info("Created new entity" + entityRef);
 
             return entityRef;
         }

--- a/src/main/java/org/terasology/servermotd/MOTDProvider.java
+++ b/src/main/java/org/terasology/servermotd/MOTDProvider.java
@@ -28,7 +28,7 @@ public class MOTDProvider {
 
     public void display(String motd, Context context) {
         NUIManager nuiManager = context.get(NUIManager.class);
-        nuiManager.pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Server MOTD", motd);
+        nuiManager.pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Server Says", motd);
     }
 
     public EntityRef getMOTDEntity(EntityManager entityManager) {

--- a/src/main/java/org/terasology/servermotd/MOTDProvider.java
+++ b/src/main/java/org/terasology/servermotd/MOTDProvider.java
@@ -39,7 +39,7 @@ public class MOTDProvider {
         Logger logger = LoggerFactory.getLogger(MOTDProvider.class);
 
         if(i.hasNext()) {
-            logger.info("Used old entity");
+            logger.info("=========================Used old entity=========================");
             int sum = 0;
             EntityRef entityRef = i.next();
             while(i.hasNext()) {
@@ -59,7 +59,7 @@ public class MOTDProvider {
             netComp.replicateMode = NetworkComponent.ReplicateMode.ALWAYS;
             entityRef.addComponent(netComp);
 
-            logger.info("Created new entity" + entityRef);
+            logger.info("=====================Created new entity===========================" + entityRef);
 
             return entityRef;
         }

--- a/src/main/java/org/terasology/servermotd/MOTDProvider.java
+++ b/src/main/java/org/terasology/servermotd/MOTDProvider.java
@@ -16,13 +16,40 @@
 package org.terasology.servermotd;
 
 import org.terasology.context.Context;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.network.NetworkComponent;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.layers.mainMenu.MessagePopup;
 
+import java.util.Iterator;
+
 public class MOTDProvider {
 
-    void display(String motd, Context context) {
+    public void display(String motd, Context context) {
         NUIManager nuiManager = context.get(NUIManager.class);
         nuiManager.pushScreen(MessagePopup.ASSET_URI, MessagePopup.class).setMessage("Server MOTD", motd);
     }
+
+    public EntityRef getMOTDEntity(EntityManager entityManager) {
+        Iterable<EntityRef> MOTDEntities = entityManager.getEntitiesWith(MOTDComponent.class);
+        Iterator<EntityRef> i = MOTDEntities.iterator();
+
+        if(i.hasNext()) {
+            return i.next();
+        }
+        else {
+            MOTDComponent MOTDComp = new MOTDComponent();
+            MOTDComp.motd = "default";
+
+            EntityRef entityRef = entityManager.create(MOTDComp);
+
+            NetworkComponent netComp = new NetworkComponent();
+            netComp.replicateMode = NetworkComponent.ReplicateMode.ALWAYS;
+            entityRef.addComponent(netComp);
+
+            return entityRef;
+        }
+    }
+
 }

--- a/src/main/java/org/terasology/servermotd/MOTDProvider.java
+++ b/src/main/java/org/terasology/servermotd/MOTDProvider.java
@@ -32,17 +32,17 @@ public class MOTDProvider {
     }
 
     public EntityRef getMOTDEntity(EntityManager entityManager) {
-        Iterable<EntityRef> MOTDEntities = entityManager.getEntitiesWith(MOTDComponent.class);
-        Iterator<EntityRef> i = MOTDEntities.iterator();
+        Iterable<EntityRef> motdEntities = entityManager.getEntitiesWith(MOTDComponent.class);
+        Iterator<EntityRef> i = motdEntities.iterator();
 
         if(i.hasNext()) {
             return i.next();
         }
         else {
-            MOTDComponent MOTDComp = new MOTDComponent();
-            MOTDComp.motd = "default";
+            MOTDComponent motdComp = new MOTDComponent();
+            motdComp.motd = "default";
 
-            EntityRef entityRef = entityManager.create(MOTDComp);
+            EntityRef entityRef = entityManager.create(motdComp);
 
             NetworkComponent netComp = new NetworkComponent();
             netComp.replicateMode = NetworkComponent.ReplicateMode.ALWAYS;

--- a/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
@@ -47,24 +47,4 @@ public class ServerMOTDSystem extends BaseComponentSystem {
         MOTDEntity = renderMOTD.getMOTDEntity(entityManager);
     }
 
-    @Command(shortDescription = "Edit server MOTD", helpText = "Edit the current server MOTD if you are admin." +
-            " Use \'a\' - to append to current MOTD" +
-            " 'w' for a new one", runOnServer = true)
-    public String editMOTD(@CommandParam(value = "a/w") String type, @CommandParam(value = "New Message") String message, @Sender EntityRef admin) {
-        MOTDComponent comp = MOTDEntity.getComponent(MOTDComponent.class);
-        if (type.equals("a")) {
-            comp.motd += message;
-        }
-
-        else if (type.equals("w")) {
-            comp.motd = message;
-        }
-
-        else {
-            return "Error in command syntax, use help editMOTD command for help";
-        }
-
-        MOTDEntity.saveComponent(comp);
-        return "Server MOTD edited use displayMOTD command to view the new MOTD";
-    }
 }

--- a/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
@@ -16,8 +16,8 @@
 package org.terasology.servermotd;
 
 import org.terasology.context.Context;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -25,38 +25,46 @@ import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
+
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class ServerMOTDSystem extends BaseComponentSystem {
-    private StringBuffer motd = new StringBuffer("default");
+    @In
+    private EntityManager entityManager;
 
     private Context context = CoreRegistry.get(Context.class);
+
+    private EntityRef MOTDEntity;
     private MOTDProvider renderMOTD = new MOTDProvider();
 
     public void initialise() {
+
     }
 
-    @ReceiveEvent
-    public void displayMOTD(DisplayMOTDEvent event, EntityRef entity) {
-        renderMOTD.display(this.motd.toString(), context);
+    @Override
+    public void postBegin() {
+        MOTDEntity = renderMOTD.getMOTDEntity(entityManager);
     }
 
     @Command(shortDescription = "Edit server MOTD", helpText = "Edit the current server MOTD if you are admin." +
             " Use \'a\' - to append to current MOTD" +
-            " 'r' for a new one", runOnServer = true)
+            " 'w' for a new one", runOnServer = true)
     public String editMOTD(@CommandParam(value = "a/w") String type, @CommandParam(value = "New Message") String message, @Sender EntityRef admin) {
+        MOTDComponent comp = MOTDEntity.getComponent(MOTDComponent.class);
         if (type.equals("a")) {
-            this.motd.append(message);
+            comp.motd += message;
         }
 
         else if (type.equals("w")) {
-            this.motd = new StringBuffer(message);
+            comp.motd = message;
         }
 
         else {
             return "Error in command syntax, use help editMOTD command for help";
         }
 
-        return "Server MOTD edited use displayMOTD command to view the new MOTD" + motd.toString();
+        MOTDEntity.saveComponent(comp);
+        return "Server MOTD edited use displayMOTD command to view the new MOTD";
     }
 }

--- a/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
@@ -21,9 +21,6 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.logic.console.commandSystem.annotations.Command;
-import org.terasology.logic.console.commandSystem.annotations.CommandParam;
-import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 

--- a/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
@@ -16,30 +16,47 @@
 package org.terasology.servermotd;
 
 import org.terasology.context.Context;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.network.NetworkMode;
-import org.terasology.network.NetworkSystem;
+import org.terasology.logic.console.commandSystem.annotations.Command;
+import org.terasology.logic.console.commandSystem.annotations.CommandParam;
+import org.terasology.logic.console.commandSystem.annotations.Sender;
 import org.terasology.registry.CoreRegistry;
-import org.terasology.registry.Share;
 
-@Share(ServerMOTD.class)
-@RegisterSystem(RegisterMode.ALWAYS)
-public class ServerMOTDSystem extends BaseComponentSystem implements ServerMOTD {
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class ServerMOTDSystem extends BaseComponentSystem {
+    private StringBuffer motd = new StringBuffer("default");
+
     private Context context = CoreRegistry.get(Context.class);
+    private MOTDProvider renderMOTD = new MOTDProvider();
 
-    @Override
     public void initialise() {
-        String motd = "default";
+    }
 
-        NetworkSystem networkSystem = context.get(NetworkSystem.class);
+    @ReceiveEvent
+    public void displayMOTD(DisplayMOTDEvent event, EntityRef entity) {
+        renderMOTD.display(this.motd.toString(), context);
+    }
 
-        if (networkSystem.getMode() == NetworkMode.CLIENT) {
-            if (motd != null && motd.length() != 0) {
-                MOTDProvider renderMOTD = new MOTDProvider();
-                renderMOTD.display(motd, context);
-            }
+    @Command(shortDescription = "Edit server MOTD", helpText = "Edit the current server MOTD if you are admin." +
+            " Use \'a\' - to append to current MOTD" +
+            " 'r' for a new one", runOnServer = true)
+    public String editMOTD(@CommandParam(value = "a/w") String type, @CommandParam(value = "New Message") String message, @Sender EntityRef admin) {
+        if (type.equals("a")) {
+            this.motd.append(message);
         }
+
+        else if (type.equals("w")) {
+            this.motd = new StringBuffer(message);
+        }
+
+        else {
+            return "Error in command syntax, use help editMOTD command for help";
+        }
+
+        return "Server MOTD edited use displayMOTD command to view the new MOTD" + motd.toString();
     }
 }

--- a/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
+++ b/src/main/java/org/terasology/servermotd/ServerMOTDSystem.java
@@ -35,7 +35,7 @@ public class ServerMOTDSystem extends BaseComponentSystem {
 
     private Context context = CoreRegistry.get(Context.class);
 
-    private EntityRef MOTDEntity;
+    private EntityRef motdEntity;
     private MOTDProvider renderMOTD = new MOTDProvider();
 
     public void initialise() {
@@ -44,7 +44,7 @@ public class ServerMOTDSystem extends BaseComponentSystem {
 
     @Override
     public void postBegin() {
-        MOTDEntity = renderMOTD.getMOTDEntity(entityManager);
+        motdEntity = renderMOTD.getMOTDEntity(entityManager);
     }
 
 }

--- a/src/main/java/org/terasology/servermotd/events/DisplayMotdEvent.java
+++ b/src/main/java/org/terasology/servermotd/events/DisplayMotdEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.servermotd;
+package org.terasology.servermotd.events;
 
-import org.terasology.entitySystem.Component;
-import org.terasology.network.FieldReplicateType;
-import org.terasology.network.Replicate;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.rendering.nui.NUIManager;
 
-public class MOTDComponent implements Component {
-    @Replicate(value = FieldReplicateType.OWNER_TO_SERVER_TO_CLIENT)
-    public String motd;
+public class DisplayMotdEvent implements Event {
+    NUIManager nuiManager;
+
+    public DisplayMotdEvent(NUIManager manager) {
+        this.nuiManager = manager;
+    }
 }

--- a/src/main/java/org/terasology/servermotd/events/DisplayMotdEvent.java
+++ b/src/main/java/org/terasology/servermotd/events/DisplayMotdEvent.java
@@ -16,12 +16,9 @@
 package org.terasology.servermotd.events;
 
 import org.terasology.entitySystem.event.Event;
-import org.terasology.rendering.nui.NUIManager;
+import org.terasology.network.ServerEvent;
 
+@ServerEvent
 public class DisplayMotdEvent implements Event {
-    NUIManager nuiManager;
 
-    public DisplayMotdEvent(NUIManager manager) {
-        this.nuiManager = manager;
-    }
 }

--- a/src/main/java/org/terasology/servermotd/events/EditMotdEvent.java
+++ b/src/main/java/org/terasology/servermotd/events/EditMotdEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.servermotd;
+package org.terasology.servermotd.events;
 
-import org.terasology.entitySystem.Component;
-import org.terasology.network.FieldReplicateType;
-import org.terasology.network.Replicate;
+import org.terasology.entitySystem.event.Event;
 
-public class MOTDComponent implements Component {
-    @Replicate(value = FieldReplicateType.OWNER_TO_SERVER_TO_CLIENT)
-    public String motd;
+public class EditMotdEvent implements Event {
+    boolean overwriteMotd;
+    String message;
+
+    public EditMotdEvent(boolean overwrite, String edit) {
+        this.overwriteMotd = overwrite;
+        this.message = edit;
+    }
 }

--- a/src/main/java/org/terasology/servermotd/events/EditMotdEvent.java
+++ b/src/main/java/org/terasology/servermotd/events/EditMotdEvent.java
@@ -16,13 +16,18 @@
 package org.terasology.servermotd.events;
 
 import org.terasology.entitySystem.event.Event;
+import org.terasology.network.ServerEvent;
 
+@ServerEvent
 public class EditMotdEvent implements Event {
-    boolean overwriteMotd;
-    String message;
+    public boolean overwriteMotd;
+    public String editMessage;
 
-    public EditMotdEvent(boolean overwrite, String edit) {
+    public void setEditMessage(String edit) {
+        this.editMessage = edit;
+    }
+
+    public void setOverwriteMotd(boolean overwrite) {
         this.overwriteMotd = overwrite;
-        this.message = edit;
     }
 }


### PR DESCRIPTION
- Resolves #1 
- Implements a event-driven approach for displaying and editing MOTD, which works consistently as opposed to the previous implementation.

### How to test
- Start a game instance, use the `Host Game` option to run a game with the ServerMOTD module activated or start a headless server with the module added in the `override.cfg`.
- Start another game instance, use the Join Game option and select the game hosted in the previous step(it would be `localhost` under the Custom tab).
- Use the `displayMotd` command to see the 
- Run `overwriteMotd` and `appendToMotd` and test if the change is replicated on every client.

### To-do before merging
- [ ] MOTD should be displayed when a new client joins
- [ ] A message pop-up might be better than a chat message.
- [ ] Resolve bug with a client being able to run `overwriteMotd` command